### PR TITLE
fix: chart aggregation Function code + SemanticModel .platform path

### DIFF
--- a/src/powerbpy/chart.py
+++ b/src/powerbpy/chart.py
@@ -8,6 +8,19 @@ import json
 
 from powerbpy.visual import _Visual
 
+# Power BI SQExpr aggregation Function codes
+_AGGREGATION_FUNCTION_CODES = {
+    "Sum": 0,
+    "Min": 1,
+    "Max": 2,
+    "Count": 3,
+    "LongCount": 4,
+    "DistinctCount": 5,
+    "CountDistinct": 5,
+    "Average": 6,
+    "Avg": 6,
+}
+
 class _Chart(_Visual):
     """A subset of the visual class, this class represents charts"""
 
@@ -133,7 +146,7 @@ class _Chart(_Visual):
                                             "Property": y_axis_var
                                         }
                                     },
-                                    "Function": 0
+                                    "Function": _AGGREGATION_FUNCTION_CODES.get(y_axis_var_aggregation_type, 0)
                                 }
                             },
                             "queryRef": f"{y_axis_var_aggregation_type}({data_source}.{y_axis_var})",
@@ -157,7 +170,7 @@ class _Chart(_Visual):
                                         "Property": y_axis_var
                                     }
                                 },
-                                "Function": 0
+                                "Function": _AGGREGATION_FUNCTION_CODES.get(y_axis_var_aggregation_type, 0)
                             }
                         },
                         "direction": "Descending"

--- a/src/powerbpy/dashboard.py
+++ b/src/powerbpy/dashboard.py
@@ -179,18 +179,18 @@ class Dashboard:
 
         ## Semantic model folder ----------------------------------------------------------------
         # .platform file
-        with open(self.platform_file_path,'r', encoding="utf-8") as file:
-            platform_file = json.load(file)
+        with open(self.sm_platform_file_path,'r', encoding="utf-8") as file:
+            sm_platform_file = json.load(file)
 
         # modify the display name
-        platform_file["metadata"]["displayName"] = f'{self.report_name}'
+        sm_platform_file["metadata"]["displayName"] = f'{self.report_name}'
 
         # update the unique UUID
-        platform_file["config"]["logicalId"] = self.sm_logical_id
+        sm_platform_file["config"]["logicalId"] = self.sm_logical_id
 
         # write to file
-        with open(self.platform_file_path,'w', encoding="utf-8") as file:
-            json.dump(platform_file, file, indent = 2)
+        with open(self.sm_platform_file_path,'w', encoding="utf-8") as file:
+            json.dump(sm_platform_file, file, indent = 2)
 
         return self
 


### PR DESCRIPTION
## Summary

Two bug fixes for issues encountered when building dashboards with multiple aggregation types.

### 1. Chart aggregation Function code (`chart.py`)

`y_axis_var_aggregation_type` parameter was accepted but ignored — `"Function": 0` (Sum) was hardcoded in both the Y-axis projection and the sort definition. All charts defaulted to Sum regardless of the aggregation type passed.

**Fix:** Added `_AGGREGATION_FUNCTION_CODES` lookup dict mapping aggregation type strings to their PBI SQExpr Function codes, and replaced both hardcoded `0` values.

```python
_AGGREGATION_FUNCTION_CODES = {
    "Sum": 0, "Min": 1, "Max": 2, "Count": 3,
    "LongCount": 4, "DistinctCount": 5, "CountDistinct": 5,
    "Average": 6, "Avg": 6,
}
```

Backwards compatible — defaults to `0` (Sum) if an unknown aggregation type is passed.

### 2. SemanticModel `.platform` displayName (`dashboard.py`)

`Dashboard.create()` used `self.platform_file_path` (Report `.platform`) instead of `self.sm_platform_file_path` when updating the SemanticModel `.platform` file. This left the SemanticModel `displayName` as `"blank_template"`, which can cause Power BI Desktop errors when the folder name doesn't match.

**Fix:** Changed to `self.sm_platform_file_path` and used a separate variable name to avoid confusion.

## Testing

Tested with a multi-page dashboard using 4 CSV datasets and DAX measures. Charts now correctly render with DistinctCount, Count, and Average aggregations.