### PR TITLE
Fix lazy imports, warnings param shadow, and missing f-string

### DIFF
--- a/src/powerbpy/dataset_csv.py
+++ b/src/powerbpy/dataset_csv.py
@@ -5,10 +5,7 @@
 
 import getpass
 import re
-import keyring # pylint: disable=import-error
-
-from azure.storage.filedatalake import DataLakeFileClient # pylint: disable=import-error
-from azure.identity import InteractiveBrowserCredential # pylint: disable=import-error
+import warnings
 
 import pandas as pd # pylint: disable=import-error
 
@@ -121,10 +118,15 @@ class _BlobCsv(_DataSet):
                  use_saved_storage_key = False,
                  sas_url = None,
                  storage_account_key = None,
-                 warnings = True):
+                 show_warnings = True):
 
         # pylint: disable=too-few-public-methods
         # pylint: disable=too-many-locals
+
+        # Lazy imports: azure and keyring are only needed for blob access
+        import keyring # pylint: disable=import-error
+        from azure.storage.filedatalake import DataLakeFileClient # pylint: disable=import-error
+        from azure.identity import InteractiveBrowserCredential # pylint: disable=import-error
 
         super().__init__(dashboard,data_path)
 
@@ -134,9 +136,9 @@ class _BlobCsv(_DataSet):
         account_name = m.group(0)
 
 
-        if warnings:
+        if show_warnings:
             if storage_account_key is not None:
-                warnings.warn("DO NOT HARD CODE CREDENTIALS!! Only provide a storage_account_key argument if you're securely retreiving it from something like azure key vault. If this code is running locally set use_saved_storage_key to true instead. Set warnings = False to disable this warning. ")
+                warnings.warn("DO NOT HARD CODE CREDENTIALS!! Only provide a storage_account_key argument if you're securely retreiving it from something like azure key vault. If this code is running locally set use_saved_storage_key to true instead. Set show_warnings = False to disable this warning. ")
 
         if sas_url is not None and use_saved_storage_key is True:
             raise ValueError("You can't save an azure storage key to your system's credential manager when providing an sas_url. Try changing use_saved_storage_key to False and try again")

--- a/src/powerbpy/shape_map.py
+++ b/src/powerbpy/shape_map.py
@@ -717,7 +717,7 @@ class _ShapeMap(_Visual):
 
         #check to make sure the dataset exists
         if not os.path.exists(dataset_file_path):
-            raise ValueError("The {dataset_name} dataset doesn't exist yet! Try adding it using Dashboard.add_local_csv() or one of the other methods for adding datasets")
+            raise ValueError(f"The {dataset_name} dataset doesn't exist yet! Try adding it using Dashboard.add_local_csv() or one of the other methods for adding datasets")
 
 
 


### PR DESCRIPTION
## Summary

Three small bug fixes in `dataset_csv.py` and `shape_map.py`:

- **Lazy imports**: Moved `azure.storage.filedatalake`, `azure.identity`, and `keyring` imports from module level into `_BlobCsv.__init__()`. This allows `_LocalCsv` to work without Azure dependencies installed — currently importing the module at all crashes if azure/keyring packages are missing.

- **`warnings` parameter renamed to `show_warnings`**: The `warnings` parameter in `_BlobCsv.__init__()` shadows Python's `warnings` module, causing `warnings.warn()` on line 139 to crash with `AttributeError: 'bool' object has no attribute 'warn'`.

- **Missing f-string prefix**: `shape_map.py:720` has a string `"The {dataset_name} dataset..."` without the `f` prefix, so the variable name is printed literally instead of its value.

## Test plan

- [ ] Verify `from powerbpy.dataset_csv import _LocalCsv` works without azure/keyring installed
- [ ] Verify `_BlobCsv` still works when azure dependencies are available
- [ ] Verify `shape_map.py` error message now interpolates the dataset name correctly